### PR TITLE
feat: Allow calling register with options, default to format: cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 ## Install
 
 ```bash
-yarn add esm esbuild-register --dev
+yarn add esbuild-register --dev
 ```
 
-You need [`esm`](https://github.com/standard-things/esm) as well because `esbuild` doesn't compile `import` and `export` statements to commonjs `require`.
-
-[`esbuild`](https://github.com/evanw/esbuild) is also required as a peer dependency.
+[`esbuild`](https://github.com/evanw/esbuild) is required as a peer dependency.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ When using Yarn, you can add an npm script:
 
 to shorten the command, now just run `yarn ts file.ts` instead.
 
+## Programmatic Usage
+
+```ts
+const { register } = require('esbuild-register/dist/node')
+
+register({
+  // ...options
+})
+```
+
 ## License
 
 MIT &copy; [EGOIST (Kevin Titor)](https://egoist.sh)
+w

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It will use `jsxFactory`, `jsxFragmentFactory` and `target` options from your `t
 When using Yarn, you can add an npm script:
 
 ```json
-"ts": "node -r esm -r esbuild-register"
+"ts": "node -r esbuild-register"
 ```
 
 to shorten the command, now just run `yarn ts file.ts` instead.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ yarn add esbuild-register --dev
 ## Usage
 
 ```bash
-node -r esm -r esbuild-register file.ts
+node -r esbuild-register file.ts
 ```
 
 It will use `jsxFactory`, `jsxFragmentFactory` and `target` options from your `tsconfig.json`

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsup src/node.ts",
-    "test": "npm run build && node -r esm -r ./register.js tests/test.ts",
+    "test": "npm run build && node -r ./register.js tests/test.ts",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
@@ -27,7 +27,6 @@
     "@types/node": "^14.0.23",
     "@types/source-map-support": "^0.5.2",
     "esbuild": "^0.8.0",
-    "esm": "^3.2.25",
     "execa": "^4.0.3",
     "tsup": "^2.0.3",
     "typescript": "^3.9.6",

--- a/register.js
+++ b/register.js
@@ -1,1 +1,4 @@
-require('./dist/node').register()
+require('./dist/node').register({
+  format: 'cjs',
+  target: `node${process.version.slice(1)}`,
+})

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,7 +1,7 @@
 import { dirname, extname } from 'path'
 import { RawSourceMap } from 'source-map'
 import sourceMapSupport from 'source-map-support'
-import { transformSync } from 'esbuild'
+import { transformSync, TransformOptions } from 'esbuild'
 import { addHook } from 'pirates'
 import { getOptions } from './options'
 
@@ -23,41 +23,42 @@ function installSourceMapSupport() {
   })
 }
 
-type EXTENSIONS = '.js' | '.jsx' | '.ts' |'.tsx'|'.mjs'
-type LOADERS = 'js' | 'jsx' | 'ts' |'tsx'
+type EXTENSIONS = '.js' | '.jsx' | '.ts' | '.tsx' | '.mjs'
+type LOADERS = 'js' | 'jsx' | 'ts' | 'tsx'
 const FILE_LOADERS: Record<EXTENSIONS, LOADERS> = {
   '.js': 'js',
   '.jsx': 'jsx',
   '.ts': 'ts',
   '.tsx': 'tsx',
   '.mjs': 'js',
-};
-
-const DEFAULT_EXTENSIONS = Object.keys(FILE_LOADERS);
-
-const getLoader = (filename: string): LOADERS => FILE_LOADERS[extname(filename) as EXTENSIONS]
-
-function compile(code: string, filename: string) {
-  const options = getOptions(dirname(filename))
-  const { code: js, warnings, map: jsSourceMap } = transformSync(code, {
-    sourcefile: filename,
-    sourcemap: true,
-    loader: getLoader(filename),
-    target: options.target,
-    jsxFactory: options.jsxFactory,
-    jsxFragment: options.jsxFragment,
-  })
-  map[filename] = jsSourceMap
-  if (warnings && warnings.length > 0) {
-    for (const warning of warnings) {
-      console.log(warning.location)
-      console.log(warning.text)
-    }
-  }
-  return js
 }
 
-export function register() {
+const DEFAULT_EXTENSIONS = Object.keys(FILE_LOADERS)
+
+const getLoader = (filename: string): LOADERS =>
+  FILE_LOADERS[extname(filename) as EXTENSIONS]
+
+export function register(esbuildOptions: TransformOptions = {}) {
+  function compile(code: string, filename: string) {
+    const options = getOptions(dirname(filename))
+    const { code: js, warnings, map: jsSourceMap } = transformSync(code, {
+      sourcefile: filename,
+      sourcemap: true,
+      loader: getLoader(filename),
+      target: options.target,
+      jsxFactory: options.jsxFactory,
+      jsxFragment: options.jsxFragment,
+      ...esbuildOptions,
+    })
+    map[filename] = jsSourceMap
+    if (warnings && warnings.length > 0) {
+      for (const warning of warnings) {
+        console.log(warning.location)
+        console.log(warning.text)
+      }
+    }
+    return js
+  }
   installSourceMapSupport()
   addHook(compile, {
     exts: DEFAULT_EXTENSIONS,

--- a/tests/fixture.cjs.ts
+++ b/tests/fixture.cjs.ts
@@ -1,0 +1,5 @@
+import fs from 'fs'
+
+if (typeof fs.readFileSync === 'function') {
+  console.log('fs imported')
+}

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,9 +1,9 @@
 import path from 'path'
-import {test} from 'uvu'
+import { test } from 'uvu'
 import assert from 'uvu/assert'
 import execa from 'execa'
 
-test('register', async ()=> {
+test('register', async () => {
   const { stdout } = await execa('node', [
     '-r',
     'esm',
@@ -14,7 +14,7 @@ test('register', async ()=> {
   assert.is(stdout, 'text')
 })
 
-test('register2', async ()=> {
+test('register2', async () => {
   const { stdout } = await execa('node', [
     '-r',
     'esm',
@@ -23,6 +23,15 @@ test('register2', async ()=> {
     `${process.cwd()}/tests/fixture.arrowFunction.ts`,
   ])
   assert.is(stdout, 'hello from ts')
+})
+
+test('register cjs', async () => {
+  const { stdout } = await execa('node', [
+    '-r',
+    `${process.cwd()}/register.js`,
+    `${process.cwd()}/tests/fixture.cjs.ts`,
+  ])
+  assert.is(stdout, 'fs imported')
 })
 
 test.run()

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -6,8 +6,6 @@ import execa from 'execa'
 test('register', async () => {
   const { stdout } = await execa('node', [
     '-r',
-    'esm',
-    '-r',
     `${process.cwd()}/register.js`,
     `${process.cwd()}/tests/fixture.ts`,
   ])
@@ -16,8 +14,6 @@ test('register', async () => {
 
 test('register2', async () => {
   const { stdout } = await execa('node', [
-    '-r',
-    'esm',
     '-r',
     `${process.cwd()}/register.js`,
     `${process.cwd()}/tests/fixture.arrowFunction.ts`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["src"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
@@ -16,6 +17,8 @@
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "src",
+    "outDir": "dist",
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
@@ -64,6 +67,7 @@
 
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
+    "declaration": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,11 +134,6 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-esm@^3.2.25:
-  version "3.2.25"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
-  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
-
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"


### PR DESCRIPTION
- Allow users to call `register` directly with any supported esbuild options from `esbuild-register/dist/register`
- Outputs "declaration" so the types are available if you're calling `register` directly
- Default to [format](https://esbuild.github.io/api/#format) `cjs`, and [target](https://esbuild.github.io/api/#target) node w/ process version number
- Allow specifying extensions to be transformed