### PR TITLE
feat: add inline source map for debugger support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "esbuild": ">=0.8.0"
+    "esbuild": ">=0.8.31"
   },
   "dependencies": {
     "pirates": "^4.0.1",
@@ -26,7 +26,7 @@
     "@egoist/prettier-config": "^0.1.0",
     "@types/node": "^14.0.23",
     "@types/source-map-support": "^0.5.2",
-    "esbuild": "^0.8.0",
+    "esbuild": "^0.8.31",
     "execa": "^4.0.3",
     "tsup": "^2.0.3",
     "typescript": "^3.9.6",

--- a/src/node.ts
+++ b/src/node.ts
@@ -48,7 +48,7 @@ export function register(
     const options = getOptions(dirname(filename))
     const { code: js, warnings, map: jsSourceMap } = transformSync(code, {
       sourcefile: filename,
-      sourcemap: true,
+      sourcemap: 'both',
       loader: getLoader(filename),
       target: options.target,
       jsxFactory: options.jsxFactory,

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,10 +124,10 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-esbuild@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.0.tgz#3173e851303dce0682ebbcbaf6072b991dd6f60e"
-  integrity sha512-xCHJpLRlU0NIANQHNsiMDNC/HlrKoye7iH5YOcoZNurauUZgMhjmm9PCal+Oo9ARYZrWxN15mykbfCX//UEvng==
+esbuild@^0.8.31:
+  version "0.8.33"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.33.tgz#4e24ab4e780b08ff5527171bf5a684594c8b56e9"
+  integrity sha512-2ms/P6Y9zJfopR9dKo2vHzhXKfGSNlquVVoVOF8YnhjuzZVrvManMVBPadBsR/t7jzIkRnwqvxrs7d4f3C3eyg==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
As of esbuild v0.8.31, it's possible to both output a source map and include it as an inline comment. Without this, there's no way for debuggers to get the source map information, so you can't set breakpoints on the correct lines.