### PR TITLE
fix: pass tsconfig `target` in lowercase to esbuild

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -20,7 +20,7 @@ export const getOptions = (
     return {
       jsxFactory: data.compilerOptions?.jsxFactory,
       jsxFragment: data.compilerOptions?.jsxFragmentFactory,
-      target: data.compilerOptions?.target,
+      target: data.compilerOptions?.target?.toLowerCase(),
     }
   }
   return {}


### PR DESCRIPTION
fix issue where uppercase targets e.g. ES2020 break esbuild because it expects it to be lowercase