### PR TITLE
feat: Allow programmatic enabling / disabling of `esbuild-register`

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,5 +1,3 @@
-require('./dist/node')
-  .register({
-    target: `node${process.version.slice(1)}`,
-  })
-  .enabled(true)
+require('./dist/node').register({
+  target: `node${process.version.slice(1)}`,
+})

--- a/register.js
+++ b/register.js
@@ -1,3 +1,5 @@
-require('./dist/node').register({
-  target: `node${process.version.slice(1)}`,
-})
+require('./dist/node')
+  .register({
+    target: `node${process.version.slice(1)}`,
+  })
+  .enabled(true)

--- a/src/node.ts
+++ b/src/node.ts
@@ -107,18 +107,16 @@ export function register(
     return js
   }
 
-  return {
-    enabled(enabled: boolean) {
-      const revert = addHook(compile, {
-        exts: extensions,
-      })
+  const revert = addHook(compile, {
+    exts: extensions,
+  })
 
-      if (enabled === true) {
-        installSourceMapSupport()
-        patchCommonJsLoader(compile)
-      } else {
-        revert()
-      }
+  installSourceMapSupport()
+  patchCommonJsLoader(compile)
+
+  return {
+    unregister() {
+      revert()
     },
   }
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -3,8 +3,8 @@ import type { RawSourceMap } from 'source-map'
 import sourceMapSupport from 'source-map-support'
 import { transformSync, TransformOptions } from 'esbuild'
 import { addHook } from 'pirates'
-import fs from 'fs';
-import module from 'module';
+import fs from 'fs'
+import module from 'module'
 import { getOptions, inferPackageFormat } from './options'
 
 const map: { [file: string]: string | RawSourceMap } = {}
@@ -25,32 +25,36 @@ function installSourceMapSupport() {
   })
 }
 
-type COMPILE = (code: string, filename: string, format?: 'cjs' | 'esm') => string
+type COMPILE = (
+  code: string,
+  filename: string,
+  format?: 'cjs' | 'esm',
+) => string
 
 /**
  * Patch the Node CJS loader to suppress the ESM error
  * https://github.com/nodejs/node/blob/069b5df/lib/internal/modules/cjs/loader.js#L1125
- * 
+ *
  * As per https://github.com/standard-things/esm/issues/868#issuecomment-594480715
  */
 function patchCommonJsLoader(compile: COMPILE) {
   // @ts-expect-error
-  const extensions = module.Module._extensions;
-  const jsHandler = extensions['.js'];
-  
-  extensions['.js'] = function(module: any, filename: string) {
+  const extensions = module.Module._extensions
+  const jsHandler = extensions['.js']
+
+  extensions['.js'] = function (module: any, filename: string) {
     try {
       return jsHandler.call(this, module, filename)
     } catch (error) {
       if (error.code !== 'ERR_REQUIRE_ESM') {
-        throw error;
+        throw error
       }
 
-      let content = fs.readFileSync(filename, 'utf8');
-      content = compile(content, filename, 'cjs');
-      module._compile(content, filename);
+      let content = fs.readFileSync(filename, 'utf8')
+      content = compile(content, filename, 'cjs')
+      module._compile(content, filename)
     }
-  };
+  }
 }
 
 type LOADERS = 'js' | 'jsx' | 'ts' | 'tsx'
@@ -79,7 +83,11 @@ export function register(
     const options = getOptions(dir)
     format = format ?? inferPackageFormat(dir, filename)
 
-    const { code: js, warnings, map: jsSourceMap } = transformSync(code, {
+    const {
+      code: js,
+      warnings,
+      map: jsSourceMap,
+    } = transformSync(code, {
       sourcefile: filename,
       sourcemap: 'both',
       loader: getLoader(filename),
@@ -98,9 +106,21 @@ export function register(
     }
     return js
   }
-  installSourceMapSupport()
-  patchCommonJsLoader(compile)
-  addHook(compile, {
-    exts: extensions,
-  })
+
+  return {
+    enabled(enabled: boolean) {
+      const revert = addHook(compile, {
+        exts: extensions,
+      })
+
+      if (enabled === true) {
+        installSourceMapSupport()
+        patchCommonJsLoader(compile)
+      } else {
+        revert()
+      }
+    },
+  }
 }
+
+export type Register = ReturnType<typeof register>


### PR DESCRIPTION
This pull requests implements programmatic enabling / disabling of `esbuild-register`.

This feature is important because when you use this package programatically, you need to be able to switch it on / off after requiring a certain file for it to not interfere with the imports after that. I ran into that with https://github.com/facebook/jest/pull/12041.

This is not a breaking change as `esbuild-register` is still enabled as soon as you `node -r` it or require it programatically. It just adds the ability to disable it when necessary.

Closes #41 