### PR TITLE
feat: Expose pirates hook options `ignoreNodeModules` and `matcher`

### DIFF
--- a/tests/fixture-register/register-with-matcher.js
+++ b/tests/fixture-register/register-with-matcher.js
@@ -1,0 +1,7 @@
+const { register } = require('../../dist/node')
+register({
+  hookIgnoreNodeModules: false,
+  hookMatcher(fileName) {
+    return fileName.includes('foo') || fileName.includes('index')
+  },
+})

--- a/tests/fixture-register/register-with-node_modules.js
+++ b/tests/fixture-register/register-with-node_modules.js
@@ -1,0 +1,4 @@
+const { register } = require('../../dist/node')
+register({
+  hookIgnoreNodeModules: false,
+})

--- a/tests/import-typescript-module/index.js
+++ b/tests/import-typescript-module/index.js
@@ -1,0 +1,3 @@
+import foo from 'foo'
+
+console.log(foo)

--- a/tests/import-typescript-module/node_modules/foo/index.ts
+++ b/tests/import-typescript-module/node_modules/foo/index.ts
@@ -1,0 +1,1 @@
+export default 'hello from typescript in node_modules' as string

--- a/tests/import-typescript-module/node_modules/foo/package.json
+++ b/tests/import-typescript-module/node_modules/foo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "foo",
+  "main": "index.ts",
+  "files": ["*"]
+}

--- a/tests/import-typescript-module/package.json
+++ b/tests/import-typescript-module/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -47,4 +47,22 @@ test('import type module', async () => {
   assert.is(stdout, 'foo')
 })
 
+test('import TypeScript npm module', async () => {
+  const { stdout } = await execa('node', [
+    '-r',
+    `${process.cwd()}/tests/fixture-register/register-with-node_modules.js`,
+    `${process.cwd()}/tests/import-typescript-module/index.js`,
+  ])
+  assert.is(stdout, 'hello from typescript in node_modules')
+})
+
+test('import TypeScript npm module with matcher', async () => {
+  const { stdout } = await execa('node', [
+    '-r',
+    `${process.cwd()}/tests/fixture-register/register-with-matcher.js`,
+    `${process.cwd()}/tests/import-typescript-module/index.js`,
+  ])
+  assert.is(stdout, 'hello from typescript in node_modules')
+})
+
 test.run()


### PR DESCRIPTION
# Description

We host private packages in the GitHub Package registry and they are raw TypeScript files (unbundled). We're already using `esbuild-register`, however today I realized that TS files in `node_modules` are not actually transformed by esbuild. This is because by default the pirates hook `ignoreNodeModules` is `true`

What this PR does is to expose 2 options from pirates' hooks `ignoreNodeModules` and `matcher`
`matcher` is used to selectively choose which files should use the hook. This is helpful to use when setting `ignoreNodeModules: false` to be able to selectively choose which node_modules we want to build. In our case, we want only org private packages to be built with esbuild but leave others as is.