### PR TITLE
feat: bundle mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "tsup src/node.ts --dts",
     "test": "npm run build && node -r ./register.js tests/test.ts",
+    "test:bundle": "npm run build && ESBUILD_REGISTER='--bundle' node -r ./register.js tests/test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/src/node.ts
+++ b/src/node.ts
@@ -12,7 +12,6 @@ import {
 import { addHook } from 'pirates'
 import fs from 'fs'
 import module from 'module'
-import process from 'process'
 import { getOptions, inferPackageFormat } from './options'
 import { removeNodePrefix } from './utils'
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -12,7 +12,7 @@ import {
 import { addHook } from 'pirates'
 import fs from 'fs'
 import module from 'module'
-import { getOptions, inferPackageFormat } from './options'
+import { getOptions, inferExternal, inferPackageFormat } from './options'
 import { removeNodePrefix } from './utils'
 
 const map: { [file: string]: string | RawSourceMap } = {}
@@ -137,6 +137,7 @@ export function register(esbuildOptions: RegisterOptions = {}) {
       const result = buildSync({
         entryPoints: [filename],
         bundle: true,
+        external: hookIgnoreNodeModules ? inferExternal(dir) : [],
         sourcemap: 'inline',
         platform: 'node',
         write: false,

--- a/src/options.ts
+++ b/src/options.ts
@@ -43,3 +43,15 @@ export const inferPackageFormat = (
     ? 'esm'
     : 'cjs'
 }
+
+export const inferExternal = (cwd: string): string[] => {
+  const { data } = joycon.loadSync(['package.json'], cwd)
+  if (data) {
+    return Object.keys({
+      ...data.dependencies,
+      ...data.devDependencies,
+      ...data.peerDependencies,
+    })
+  }
+  return []
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import process from 'process'
 import JoyCon from 'joycon'
 import { parse } from 'jsonc-parser'
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import process from 'process'
 import JoyCon from 'joycon'
 import { parse } from 'jsonc-parser'
 
@@ -20,7 +21,9 @@ export const getOptions = (
     return {
       jsxFactory: data.compilerOptions?.jsxFactory,
       jsxFragment: data.compilerOptions?.jsxFragmentFactory,
-      target: data.compilerOptions?.target?.toLowerCase(),
+      target:
+        data.compilerOptions?.target?.toLowerCase() ??
+        `node${process.versions.node}`,
     }
   }
   return {}

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,5 +1,5 @@
 import { test } from 'uvu'
-import assert from 'uvu/assert'
+import * as assert from 'uvu/assert'
 import execa from 'execa'
 
 test('register', async () => {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,5 +1,5 @@
 import { test } from 'uvu'
-import * as assert from 'uvu/assert'
+import assert from 'uvu/assert'
 import execa from 'execa'
 
 test('register', async () => {


### PR DESCRIPTION
Caveats:
- Does not support plugins, etc.
- `__dirname` and `__filename` may not work as expected.
- `hookIgnoreNodeModules` and `hookMatcher` are ignored.

Note: I did not generate external sourcemap and feed it to source-map-support. Node.js already has a built-in `--enable-source-maps` flag. So I'll leave this function not implemented.

Should resolve #15.

Instead of using environment variable, another possible usage I think is:
```
node -r esbuild-register/bundle main.ts
```
Which is implemented by adding a bundle.js in root folder. Do you think this may be useful?