### PR TITLE
Use esbuild to resolve paths

### DIFF
--- a/src/esbuildResolveSync.ts
+++ b/src/esbuildResolveSync.ts
@@ -1,0 +1,35 @@
+import { buildSync } from "esbuild"
+import Module from "module"
+import path from 'path'
+
+export const esbuildResolveSync = (id: string, parent: Module) => {
+  const meta = buildSync({
+    stdin: {
+      contents: `require(${JSON.stringify(id)})`,
+      resolveDir: parent.path,
+    },
+    write: false,
+    metafile: true,
+    bundle: true,
+    treeShaking: 'ignore-annotations',
+    platform: 'node',
+    loader: {
+      '.js': 'text',
+      '.ts': 'text',
+      '.jsx': 'text',
+      '.tsx': 'text',
+      '.mjs': 'text',
+      '.mts': 'text',
+      '.mjsx': 'text',
+      '.mtsx': 'text',
+      '.cjs': 'text',
+      '.cts': 'text',
+      '.cjsx': 'text',
+      '.ctsx': 'text',
+    },
+  })
+  
+  const result = meta.metafile?.inputs && path.resolve(Object.keys(meta.metafile.inputs)[0])
+
+  return result
+}

--- a/src/esbuildResolveSync.ts
+++ b/src/esbuildResolveSync.ts
@@ -1,5 +1,5 @@
-import { buildSync } from "esbuild"
-import Module from "module"
+import { buildSync } from 'esbuild'
+import Module from 'module'
 import path from 'path'
 
 export const esbuildResolveSync = (id: string, parent: Module) => {
@@ -28,8 +28,9 @@ export const esbuildResolveSync = (id: string, parent: Module) => {
       '.ctsx': 'text',
     },
   })
-  
-  const result = meta.metafile?.inputs && path.resolve(Object.keys(meta.metafile.inputs)[0])
+
+  const result =
+    meta.metafile?.inputs && path.resolve(Object.keys(meta.metafile.inputs)[0])
 
   return result
 }

--- a/src/esbuildResolveSync.ts
+++ b/src/esbuildResolveSync.ts
@@ -3,34 +3,39 @@ import Module from 'module'
 import path from 'path'
 
 export const esbuildResolveSync = (id: string, parent: Module) => {
-  const meta = buildSync({
-    stdin: {
-      contents: `require(${JSON.stringify(id)})`,
-      resolveDir: parent.path,
-    },
-    write: false,
-    metafile: true,
-    bundle: true,
-    treeShaking: 'ignore-annotations',
-    platform: 'node',
-    loader: {
-      '.js': 'text',
-      '.ts': 'text',
-      '.jsx': 'text',
-      '.tsx': 'text',
-      '.mjs': 'text',
-      '.mts': 'text',
-      '.mjsx': 'text',
-      '.mtsx': 'text',
-      '.cjs': 'text',
-      '.cts': 'text',
-      '.cjsx': 'text',
-      '.ctsx': 'text',
-    },
-  })
+  try {
+    const meta = buildSync({
+      stdin: {
+        contents: `require(${JSON.stringify(id)})`,
+        resolveDir: parent.path,
+      },
+      write: false,
+      metafile: true,
+      bundle: true,
+      treeShaking: 'ignore-annotations',
+      platform: 'node',
+      loader: {
+        '.js': 'text',
+        '.ts': 'text',
+        '.jsx': 'text',
+        '.tsx': 'text',
+        '.mjs': 'text',
+        '.mts': 'text',
+        '.mjsx': 'text',
+        '.mtsx': 'text',
+        '.cjs': 'text',
+        '.cts': 'text',
+        '.cjsx': 'text',
+        '.ctsx': 'text',
+      },
+      logLevel: 'silent',
+    })
 
-  const result =
-    meta.metafile?.inputs && path.resolve(Object.keys(meta.metafile.inputs)[0])
+    const result =
+      meta.metafile?.inputs && path.resolve(Object.keys(meta.metafile.inputs)[0])
 
-  return result
+    return result
+  } catch (e) {
+    return undefined;
+  }
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -135,28 +135,28 @@ export function register(esbuildOptions: RegisterOptions = {}) {
   installSourceMapSupport()
   patchCommonJsLoader(compile)
 
-  const Module = require('module');
-  const originalResolveFilename = Module._resolveFilename;
+  const Module = require('module')
+  const originalResolveFilename = Module._resolveFilename
 
-  const coreModules = new Set(Module.builtinModules);
+  const coreModules = new Set(Module.builtinModules)
 
   Module._resolveFilename = function (request: string, parent: any): string {
     if (!parent) {
-      return originalResolveFilename.apply(this, arguments); 
+      return originalResolveFilename.apply(this, arguments)
     }
 
-    const isCoreModule = coreModules.has(request);
+    const isCoreModule = coreModules.has(request)
     if (!isCoreModule) {
-      const found = esbuildResolveSync(request, parent);
+      const found = esbuildResolveSync(request, parent)
       if (found) {
-        const modifiedArguments = [found, ...[].slice.call(arguments, 1)]; // Passes all arguments. Even those that is not specified above.
+        const modifiedArguments = [found, ...[].slice.call(arguments, 1)] // Passes all arguments. Even those that is not specified above.
         // tslint:disable-next-line:no-invalid-this
-        return originalResolveFilename.apply(this, modifiedArguments);
+        return originalResolveFilename.apply(this, modifiedArguments)
       }
     }
     // tslint:disable-next-line:no-invalid-this
-    return originalResolveFilename.apply(this, arguments);
-  };
+    return originalResolveFilename.apply(this, arguments)
+  }
 
   return {
     unregister() {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -65,4 +65,16 @@ test('import TypeScript npm module with matcher', async () => {
   assert.is(stdout, 'hello from typescript in node_modules')
 })
 
+test('tsconfig-paths', async() => {
+  const cwd2 = `${process.cwd()}/tests/tsconfig-paths`
+  const { stdout } = await execa('node', [
+    '-r',
+    `${process.cwd()}/register.js`,
+    `${process.cwd()}/tests/tsconfig-paths/src/utils/fixture.ts`,
+  ], {
+    cwd: cwd2,
+  })
+  assert.equal(stdout, 'foo1\nfoo1')
+})
+
 test.run()

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -77,4 +77,19 @@ test('tsconfig-paths', async() => {
   assert.equal(stdout, 'foo1\nfoo1')
 })
 
+test('tsconfig-paths handles not found', async() => {
+  const cwd2 = `${process.cwd()}/tests/tsconfig-paths`
+
+  const { stderr } = await execa('node', [
+    '-r',
+    `${process.cwd()}/register.js`,
+    `${process.cwd()}/tests/tsconfig-paths/src/utils/notfound.ts`,
+  ], {
+    cwd: cwd2,
+    reject: false,
+  })
+  assert.ok(stderr.includes(`Error: Cannot find module '@apis/foos'`))
+})
+
+
 test.run()

--- a/tests/tsconfig-paths/node_modules/@apis/foo.ts
+++ b/tests/tsconfig-paths/node_modules/@apis/foo.ts
@@ -1,0 +1,3 @@
+export const foo = () => {
+  console.info('error!')
+}

--- a/tests/tsconfig-paths/src/apis/foo.ts
+++ b/tests/tsconfig-paths/src/apis/foo.ts
@@ -1,0 +1,5 @@
+import { f } from './fuck';
+
+export const foo = () => {
+  console.info('foo' + f)
+}

--- a/tests/tsconfig-paths/src/apis/fuck.ts
+++ b/tests/tsconfig-paths/src/apis/fuck.ts
@@ -1,0 +1,1 @@
+export const f = 1;

--- a/tests/tsconfig-paths/src/apis/index.ts
+++ b/tests/tsconfig-paths/src/apis/index.ts
@@ -1,0 +1,3 @@
+export const index = () => {
+  console.info('index')
+}

--- a/tests/tsconfig-paths/src/utils/fixture.ts
+++ b/tests/tsconfig-paths/src/utils/fixture.ts
@@ -1,0 +1,5 @@
+import { foo as foo2 } from 'src/apis/foo'
+import { foo } from '@apis/foo'
+
+foo()
+foo2()

--- a/tests/tsconfig-paths/src/utils/notfound.ts
+++ b/tests/tsconfig-paths/src/utils/notfound.ts
@@ -1,0 +1,5 @@
+import { foo as foo2 } from 'src/apis/foo'
+import { foo } from '@apis/foos'
+
+foo()
+foo2()

--- a/tests/tsconfig-paths/tsconfig.json
+++ b/tests/tsconfig-paths/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",                               /* Allow JavaScript files to be a part o
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,
+    "skipLibCheck": true,                                /* Skip type checking all .d.ts files. */
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@apis/*": ["src/apis/*"],
+      "@utils/*": ["src/utils/*"]
+    }
+  }
+}


### PR DESCRIPTION
This should be good enough to resolve https://github.com/egoist/esbuild-register/issues/46

The trick is monkey-patching ` require('module')._resolveFilename` just as `tsconfig-paths` does in https://github.com/dividab/tsconfig-paths/blob/8a76c5c4c35b45bec67bd71b74ce0cf5cb12bb9f/src/register.ts#L76

However, we cannot use esbuild's newly exposed [Resolve API](https://github.com/evanw/esbuild/pull/1881) directly because `_resolveFilename` is expected to be synchronous, but `Resolve API` requires using a plugin, which is not allowed in esbuild's sync mode. 

src/esbuildResolveSync.ts resolves the problem by tricking esbuild to bundle a small `require(${JSON.stringify(id)})`, while taking all javascript/typescript files as plaintext, therefore avoiding them to be visited at once. Then, we can read the real  path of the import specifier right from the esbuild's metafile.