### PR TITLE
fix: prefer using native sourcemap support

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -5,6 +5,7 @@ import { transformSync, TransformOptions } from 'esbuild'
 import { addHook } from 'pirates'
 import fs from 'fs'
 import module from 'module'
+import process from 'process'
 import { getOptions, inferPackageFormat } from './options'
 import { removeNodePrefix } from './utils'
 import { registerTsconfigPaths } from './tsconfig-paths'
@@ -12,19 +13,23 @@ import { registerTsconfigPaths } from './tsconfig-paths'
 const map: { [file: string]: string | RawSourceMap } = {}
 
 function installSourceMapSupport() {
-  sourceMapSupport.install({
-    handleUncaughtExceptions: false,
-    environment: 'node',
-    retrieveSourceMap(file) {
-      if (map[file]) {
-        return {
-          url: file,
-          map: map[file],
+  if ((process as any).setSourceMapsEnabled) {
+    (process as any).setSourceMapsEnabled(true);
+  } else {
+    sourceMapSupport.install({
+      handleUncaughtExceptions: false,
+      environment: 'node',
+      retrieveSourceMap(file) {
+        if (map[file]) {
+          return {
+            url: file,
+            map: map[file],
+          }
         }
-      }
-      return null
-    },
-  })
+        return null
+      },
+    })
+  }
 }
 
 type COMPILE = (


### PR DESCRIPTION
I discovered that it is now possible to [programmatically enable Node's builtin sourcemap support](https://nodejs.org/dist/latest-v16.x/docs/api/process.html#processsetsourcemapsenabledval).

This PR first checks if we can use the native source map support, before deferring to the `source-map-support` module.

resolves #33 

