### PR TITLE
fix: do not crash when project cli option is supplied

### DIFF
--- a/src/tsconfig-paths.ts
+++ b/src/tsconfig-paths.ts
@@ -4,7 +4,7 @@ import { loadConfig, createMatchPath } from 'tsconfig-paths'
 const noOp = () => {}
 
 export function registerTsconfigPaths(): () => void {
-  const configLoaderResult = loadConfig()
+  const configLoaderResult = loadConfig(process.cwd())
 
   if (configLoaderResult.resultType === 'failed') {
     return noOp


### PR DESCRIPTION
Fixes #66

esbuild-register calls `loadConfig` from 'tsconfig-paths' without arguments.

https://github.com/egoist/esbuild-register/blob/e41493714fc89f8f67c5f44401aecd3ee6b6867a/src/tsconfig-paths.ts#L7

`loadConfig` uses a default for its `cwd` param

https://github.com/dividab/tsconfig-paths/blob/8a76c5c4c35b45bec67bd71b74ce0cf5cb12bb9f/src/config-loader.ts#L41

which is read from `--project` flag in `process.argv`

https://github.com/dividab/tsconfig-paths/blob/8a76c5c4c35b45bec67bd71b74ce0cf5cb12bb9f/src/options.ts

The fix is to supply `cwd` to `loadConfig` explicitly.