### PR TITLE
fix: node version

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ const nodeVersion = (process.versions.node.match(/^(\d+)\.(\d+)/) || [])
 
 // Use a simple regexp to replace `node:id` with `id` from source code
 export function removeNodePrefix(code: string) {
-  if (nodeVersion[0] <= 14 && nodeVersion[1] < 18) {
+  if (nodeVersion[0] < 14 || (nodeVersion[0] === 14 && nodeVersion[1] < 18)) {
     return code.replace(
       /([\b\(])require\("node:([^"]+)"\)([\b\)])/g,
       '$1require("$2")$3',


### PR DESCRIPTION
when node version is like `12.20.0`, the value of `nodeVersion[1]` this will be 20, 
this will cause the `removeNodePrefix` to be skipped