### PR TITLE
fix: avoid literally writing `import.meta.url`

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -113,7 +113,7 @@ export function register(esbuildOptions: RegisterOptions = {}) {
   const compile: COMPILE = function compile(code, filename, format) {
     const define = {
       // Computed property name is used because literally writing
-      // `import.meta.url` may be transformed by esbuild-register itself
+      // `import.meta.url` may be transformed during our build process
       ['IMPORT.META.URL'.toLowerCase()]: IMPORT_META_URL_VARIABLE_NAME,
       ...overrides.define,
     }

--- a/src/node.ts
+++ b/src/node.ts
@@ -112,7 +112,9 @@ export function register(esbuildOptions: RegisterOptions = {}) {
 
   const compile: COMPILE = function compile(code, filename, format) {
     const define = {
-      'import.meta.url': IMPORT_META_URL_VARIABLE_NAME,
+      // Computed property name is used because literally writing
+      // `import.meta.url` may be transformed by esbuild-register itself
+      ['IMPORT.META.URL'.toLowerCase()]: IMPORT_META_URL_VARIABLE_NAME,
       ...overrides.define,
     }
     const banner = `const ${IMPORT_META_URL_VARIABLE_NAME} = require('url').pathToFileURL(__filename).href;${


### PR DESCRIPTION
Hi, I just forked this repository and run tests locally to see the "import.meta.url support" test fail.

Some investigation showed that the litral `'import.meta.url'` in `node.js` was somehow replaced with `__import_meta_url` after build.

This PR mitigates the problem by avoiding literal `import.meta.url`.

